### PR TITLE
Have hidden workspaces not clutter active one

### DIFF
--- a/window.js
+++ b/window.js
@@ -80,6 +80,10 @@ export default class Window {
 
   hide() {
     this.instance.minimize();
+    this.instance.change_workspace_by_index(
+        (global.workspace_manager.get_n_workspaces() - 1),
+      false
+    );
   }
 
   focused() {


### PR DESCRIPTION
Through my experience using this amazing extension, i felt that, working with multiple scratchpads, our active main workspace gets quite cluttered

This mitigates it by sending it to the last workspace

Later, if needed, it might be interesting to select which workspace to use as the "invisible" one through config.json