### PR TITLE
Config option to move window to scratch workspace when hiding

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Here's an initial example to get started:
     "bindings": [
       { "wmclass": "^Slack$", "keybind": "<super>i" },
       { "wmclass": "^kitty$", "keybind": "<super>Return" }
-    ]
+    ],
+    "mode": "minimize"
 }
 ```
 
@@ -48,6 +49,7 @@ measure:
     * `wmclass`: regex used to target a window based on its class
     * `title`: regex used to target a window based on its title
     * `keybind`: shortcut in `[<Modifiers>+]<keycode>` notation
+* `mode`: either `minimize` (minimize the window when hiding) or `last_workspace` (move to last workspace when hiding)
 
 > [!NOTE]
 > You only need to specify `wmclass` _or_ `title`. Of the two, `wmclass` is

--- a/window.js
+++ b/window.js
@@ -1,9 +1,11 @@
 import Shell from 'gi://Shell';
 
+const LAST_WORKSPACE_INDEX = 9;
+
 export default class Window {
   static appSystem = Shell.AppSystem.get_default();
 
-  static find({title, wmclass}) {
+  static find({ title, wmclass }) {
     let windows = [];
 
     // Find the Gnome window instance
@@ -79,7 +81,8 @@ export default class Window {
   }
 
   hide() {
-    this.instance.minimize();
+    // this.instance.minimize();
+    this.instance.change_workspace_by_index(LAST_WORKSPACE_INDEX, false)
   }
 
   focused() {

--- a/window.js
+++ b/window.js
@@ -1,6 +1,5 @@
 import Shell from 'gi://Shell';
-
-const LAST_WORKSPACE_INDEX = 9;
+import Config from './config.js';
 
 export default class Window {
   static appSystem = Shell.AppSystem.get_default();
@@ -41,7 +40,8 @@ export default class Window {
   }
 
   constructor(gnome_window) {
-    this.instance = gnome_window
+    this.instance = gnome_window;
+    this.config = new Config().parse();
   }
 
   arrange(windowWidth, windowHeight) {
@@ -81,8 +81,12 @@ export default class Window {
   }
 
   hide() {
-    // this.instance.minimize();
-    this.instance.change_workspace_by_index(LAST_WORKSPACE_INDEX, false)
+    if (this.config?.mode == "last_workspace") {
+      const last_workspace_index = global.workspace_manager.get_n_workspaces() - 1;
+      this.instance.change_workspace_by_index(last_workspace_index, false);
+    } else {  // default behavior
+      this.instance.minimize();
+    }
   }
 
   focused() {


### PR DESCRIPTION
I just stumbled upon this extension as an alternative to the auto type feature of KeepassXC (which doesn't work on Wayland) and it's great! Many thanks for creating this.

For my specific use-case, I actually want my windows to stay open on a scratch workspace, and simply get moved from/to there. I added a simple config option for this behaviour, which I thought might be useful for others, too. 