### PR TITLE
Add optional config flag to launch program

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Here's an initial example to get started:
     "hide_keybind": "<super>n",
     "bindings": [
       { "wmclass": "^Slack$", "keybind": "<super>i" },
-      { "wmclass": "^kitty$", "keybind": "<super>Return" }
+      { "wmclass": "^kitty$", "keybind": "<super>Return", "launch_cmd": "kitty" }
     ]
 }
 ```
@@ -48,6 +48,7 @@ measure:
     * `wmclass`: regex used to target a window based on its class
     * `title`: regex used to target a window based on its title
     * `keybind`: shortcut in `[<Modifiers>+]<keycode>` notation
+    * `launch_cmd`: optional command to run to launch the program if there are no windows open. can be ommitted.
 
 > [!NOTE]
 > You only need to specify `wmclass` _or_ `title`. Of the two, `wmclass` is

--- a/extension.js
+++ b/extension.js
@@ -1,7 +1,8 @@
-import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
-import Config from './config.js';
-import KeyBinder from './keybinder.js';
-import Window from './window.js';
+import { Extension } from "resource:///org/gnome/shell/extensions/extension.js";
+import Gio from "gi://Gio";
+import Config from "./config.js";
+import KeyBinder from "./keybinder.js";
+import Window from "./window.js";
 
 export default class ScratchpadExtension extends Extension {
   enable() {
@@ -30,7 +31,22 @@ export default class ScratchpadExtension extends Extension {
   toggleWindow(binding) {
     let win = Window.find(binding);
 
-    if (win === null) { return; }
+    if (!win) {
+      if (binding.launch_cmd && !this._launching) {
+        this._launching = true;
+        const cmd = binding.launch_cmd.split(' ');
+        try {
+          Gio.Subprocess.new(cmd, Gio.SubprocessFlags.NONE);
+        } catch (e) {
+          log(
+            `[gnome-scratchpad] failed to launch [cmd=${binding.launch_cmd}]: ${e.message}`)
+        } finally {
+          setTimeout(() => { this._launching = false; }, 1000);
+        }
+      }
+
+      return;
+    }
 
     if (win.focused()) {
       win.hide();
@@ -39,6 +55,7 @@ export default class ScratchpadExtension extends Extension {
       win.show();
     }
   }
+
 
   hideWindows() {
     for (const binding of this.config.bindings) {


### PR DESCRIPTION
Hey!

Coming over from iTerm2, one thing I missed is not having to manually open the window first. This PR adds an optional `launch_cmd` key in `config.json` to run a command if the keybind is pressed but a window is not found. Includes logic to avoid opening 10000000 windows if the user spams the keybind while it's loading.